### PR TITLE
Add native sql close.

### DIFF
--- a/src/mysql/impl/sys/DatabaseConnection.hx
+++ b/src/mysql/impl/sys/DatabaseConnection.hx
@@ -168,4 +168,10 @@ class DatabaseConnection extends DatabaseConnectionBase {
         }
         return sql;
     }
+
+    override function close() {
+		super.close();
+		if (_nativeConnection != null)
+			_nativeConnection.close();
+	}
 }


### PR DESCRIPTION
If it is not closed, a large number of requests will result in MySQl Too many connections errors.